### PR TITLE
CI & command-line build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,95 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      ## MacOS Setup
+      - name: install lazarus (Mac)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install lazarus
+          echo /Applications/Lazarus >> $GITHUB_PATH
+
+      ## Linux Setup
+
+      - name: install lazarus (linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install lazarus
+
+
+      ## Windows Setup
+
+      - name: install make (windows)
+        if: matrix.os == 'windows-latest'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install make
+
+      - name: install 32-bit lazarus (windows)
+        if: matrix.os == 'windows-latest'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install --x86 lazarus
+
+      # https://stackoverflow.com/a/64831469
+      - name: add lazarus to path (windows)
+        if: matrix.os == 'windows-latest'
+        run: echo "C:\lazarus" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      ## Build
+
+      - run: lazbuild --version
+
+      - name: fpc version
+        run: fpc -iW
+        if: matrix.os != 'windows-latest'
+
+      - uses: actions/checkout@v2
+
+      - run: make clean
+
+      - run: make smartset_master
+      - run: make smartset_master_office
+      # - run: make smartset_adv2
+      # - run: make smartset_fsedge
+      # - run: make smartset_savant_elite
+      - run: make smartset_tko
+      - run: make smartset_rgb
+
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: SmartSetMaster-${{ runner.os }}
+          path: SmartSetMaster
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: SmartSetMasterOffice-${{ runner.os }}
+          path: SmartSetMasterOffice
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: SmartSetAdv2-${{ runner.os }}
+          path: SmartSetAdv2
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: SmartSetFSEdgePro-${{ runner.os }}
+          path: SmartSetFSEdgePro
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: SmartSetSavantElite-${{ runner.os }}
+          path: SmartSetSavantElite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,21 +13,21 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - uses: actions/checkout@v2
+
       ## MacOS Setup
       - name: install lazarus (Mac)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install lazarus
+          make install-lazarus-mac
           echo /Applications/Lazarus >> $GITHUB_PATH
 
       ## Linux Setup
-
       - name: install lazarus (linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install lazarus
-
 
       ## Windows Setup
 
@@ -55,8 +55,6 @@ jobs:
       - name: fpc version
         run: fpc -iW
         if: matrix.os != 'windows-latest'
-
-      - uses: actions/checkout@v2
 
       - run: make clean
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,19 @@ trace.log
 SmartSetAdv2/SmartSetKeyboard.lps
 SmartSetFSEdgePro/SmartSetFSEdge.lps
 SmartSetMaster/devmode.on
+
+Components/**/x86_64-darwin
+Components/**/x86_64-linux
+Components/**/x86_64-win64
+Components/**/i386-win32
+
+SmartSetAdv2/Adv2 SmartSet App (Mac)
+SmartSetAdv2/Adv2 SmartSet App (PC)
+SmartSetFSEdgePro/SmartSet App-Freestyle (PC)
+SmartSetMaster/SmartSetMaster (PC)
+SmartSetMasterOffice/SmartSetMasterErgo (Mac)
+SmartSetMasterOffice/SmartSetMasterOffice (PC)
+SmartSetRGB/SmartSet App-Freestyle (Mac)
+SmartSetRGB/SmartSet App-Freestyle (PC)
+SmartSetSavantElite/SE2 SmartSet App (Mac)
+SmartSetTKO/SmartSetTKO

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"alefragnani.pascal"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/Common/eject_usb.pas
+++ b/Common/eject_usb.pas
@@ -128,6 +128,19 @@ type
 
   {$endif}
 
+  {$ifdef Linux}
+  function EjectUSB(const DriveLetter: string): boolean;
+  begin
+    result := false;
+  end;
+
+  function EjectVolume(drivePath: string): boolean;
+  begin
+    result := false;
+  end;
+
+  {$endif}
+
   {$ifdef Win32}
   function EjectUSB(const DriveLetter: string): boolean;
   const

--- a/Common/u_const.pas
+++ b/Common/u_const.pas
@@ -13,6 +13,7 @@ interface
 uses
   {$ifdef Win32}Windows, shlobj, w32internetaccess, {$endif}
   {$ifdef Darwin}LCLIntf, ns_url_request, CocoaUtils, CocoaAll, {$endif}
+  {$ifdef Linux}LCLIntf, {$endif}
   lcltype, Classes, SysUtils, FileUtil, Controls, Graphics, character, LazUTF8, U_Keys, Buttons,
   internetaccess, LazFileUtils, u_kinesis_device, registry, ExtCtrls, u_led_ind;
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,128 @@
+#### Platform-specific settings
+
+ifeq ($(OS),Windows_NT)
+	exe = ".exe"
+	platform = i386-win32
+	lazflags = --cpu=i386 --widgetset=win32
+else
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)
+		platform = x86_64-linux
+		lazflags = --widgetset=gtk2
+    endif
+    ifeq ($(UNAME_S),Darwin)
+		platform = x86_64-darwin
+		lazflags = --widgetset=cocoa --lazarusdir=/Applications/Lazarus
+    endif
+endif
+
+lazbuild = lazbuild $(lazflags)
+
+
+#### Libraries
+
+creosource = Components/CreoSource/lib/$(platform)/creosource.compiled
+eccontrols = Components/ecc_0-9-6-10_16-06-15/EC_Controls/lib/$(platform)/eccontrols.compiled
+installpkg = Components/HSButton0.9/HSButton/lib/$(platform)/installpkg.compiled
+bgrabitmappack = Components/bgrabitmap-master/bgrabitmap/lib/$(platform)/3.0.4/BGRABitmapPack.compiled
+richmemopackage = Components/richmemo/lib/$(platform)/richmemopackage.compiled
+uecontrols = Components/ueControls_v6.0/lib/$(platform)/uEControls.compiled
+gifviewer = Components/TGIFViewer-master/TGIFViewer-master/package/lib/$(platform)/gifviewer_pkg.compiled
+bgracontrols = Components/bgracontrols-master/lib/$(platform)/3.0.4/bgracontrols.compiled
+mbcolorliblaz = Components/mbColorLib-2.2.1/mbColorLib/lib/$(platform)/mbColorLibLaz.compiled
+
+
+#### Apps
+
+# GNU Make doesn't handle spaces or parens in filenames very well,
+# so it's difficult to reference the built executables.
+# Instead, just using phony targets for now and accepting that they will
+# often be unnecessarily rebuilt. Can the exectuables be renamed?
+
+# smartset_fsedge := 'SmartSetFSEdgePro/SmartSet\ App-Freestyle\ \(PC\)'$(exe)
+# smartset_rgb := 'SmartSetRGB/SmartSet\ App-Freestyle\ \(Mac\)'$(exe)
+# smartset_adv2 := 'SmartSetAdv2/SmartSet\ App\ \(PC\)'$(exe)
+# smartset_savant_elite := 'SmartSetSavantElite/SE2\ SmartSet\ App\ \(Mac\)'$(exe)
+
+.PHONY: all smartset_adv2 smartset_fsedge smartset_rgb smartset_savant_elite smartset_master_office smartset tko
+
+all: smartset_master smartset_master_office
+
+smartset_fsedge = smartset_fsedge
+smartset_rgb = smartset_rgb
+smartset_adv2 = smartset_adv2
+smartset_savant_elite = smartset_savant_elite
+smartset_master = smartset_master
+smartset_master_office = smartset_master_office
+smartset_tko = smartset_tko
+
+
+#### Rules
+
+$(smartset_fsedge): $(creosource) $(eccontrols) $(installpkg) $(richmemopackage) $(uecontrols)
+	$(lazbuild) SmartSetFSEdgePro/SmartSetFSEdge.lpi
+
+$(smartset_rgb): $(bgracontrols) $(creosource) $(eccontrols) $(installpkg) $(richmemopackage) $(gifviewer) $(mbcolorliblaz) $(uecontrols)
+	$(lazbuild) SmartSetRGB/SmartSetFSEdge.lpi
+
+$(smartset_adv2): $(creosource) $(eccontrols) $(installpkg) $(richmemopackage) $(uecontrols)
+	$(lazbuild) SmartSetAdv2/SmartSetKeyboard.lpi
+
+$(smartset_savant_elite): $(bgracontrols) $(richmemopackage) $(uecontrols)
+	$(lazbuild) SmartSetSavantElite/SE2ConfigAppWin.lpi
+
+$(smartset_master): $(mbcolorliblaz) $(gifviewer) $(eccontrols) $(uecontrols) $(richmemopackage) $(creosource) $(installpkg)
+	$(lazbuild) SmartSetMaster/SmartSetMaster.lpi
+
+$(smartset_master_office): $(mbcolorliblaz) $(gifviewer) $(eccontrols) $(uecontrols) $(richmemopackage) $(creosource) $(installpkg)
+	$(lazbuild) SmartSetMasterOffice/SmartSetMasterOffice.lpi
+
+$(smartset_tko): $(eccontrols) $(mbcolorliblaz) $(uecontrols) $(gifviewer) $(richmemopackage) $(creosource) $(installpkg)
+	$(lazbuild) SmartSetTKO/SmartSetTKO.lpi
+
+$(uecontrols): $(bgrabitmappack)
+	$(lazbuild) Components/ueControls_v6.0/uecontrols.lpk
+
+$(richmemopackage):
+	$(lazbuild) Components/richmemo/richmemopackage.lpk
+
+$(gifviewer):
+	$(lazbuild) Components/TGIFViewer-master/TGIFViewer-master/package/gifviewer_pkg.lpk
+
+$(bgracontrols): $(bgrabitmappack)
+	$(lazbuild) Components/bgracontrols-master/bgracontrols.lpk
+
+$(bgrabitmappack):
+	$(lazbuild) Components/bgrabitmap-master/bgrabitmap/bgrabitmappack.lpk
+
+$(mbcolorliblaz): $(bgrabitmappack)
+	$(lazbuild) Components/mbColorLib-2.2.1/mbColorLib/mbcolorliblaz.lpk
+
+$(creosource) : $(bgrabitmappack) $(bgracontrols)
+	$(lazbuild) Components/CreoSource/creosource.lpk
+
+$(eccontrols):
+	$(lazbuild) Components/ecc_0-9-6-10_16-06-15/EC_Controls/eccontrols.lpk
+
+$(installpkg):
+	$(lazbuild) Components/HSButton0.9/HSButton/installpkg.lpk
+
+clean:
+	rm -rf \
+		Components/richmemo/lib/* \
+		Components/ecc_0-9-6-10_16-06-15/EC_Controls/lib/* \
+		Components/mbColorLib-2.2.1/mbColorLib/lib/* \
+		Components/TGIFViewer-master/TGIFViewer-master/package/lib/* \
+		Components/CreoSource/lib/* \
+		Components/HSButton0.9/HSButton/lib/* \
+		Components/bgrabitmap-master/bgrabitmap/lib/* \
+		Components/bgracontrols-master/lib/* \
+		Components/ueControls_v6.0/lib/* \
+		SmartSetAdv2/lib \
+		SmartSetFSEdgePro/lib \
+		SmartSetMaster/lib \
+		SmartSetSavantElite/lib \
+		"SmartSetAdv2/Adv2 SmartSet App (Mac)" \
+		"SmartSetFSEdgePro/SmartSet App-Freestyle (PC)" \
+		"SmartSetMaster/SmartSetMaster (PC)" \
+		"SmartSetSavantElite/SE2 SmartSet App (Mac)"

--- a/Makefile
+++ b/Makefile
@@ -126,3 +126,40 @@ clean:
 		"SmartSetFSEdgePro/SmartSet App-Freestyle (PC)" \
 		"SmartSetMaster/SmartSetMaster (PC)" \
 		"SmartSetSavantElite/SE2 SmartSet App (Mac)"
+
+################################################
+# Compiler Installation
+################################################
+
+DEB_LAZARUS = "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.0.12/lazarus-project_2.0.12-0_amd64.deb/download"
+DEB_FPC_LAZ = "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.0.12/fpc-laz_3.2.0-1_amd64.deb/download"
+DEB_FPC_SRC = "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.0.12/fpc-src_3.2.0-1_amd64.deb/download"
+
+# Lazarus 2.1+ causes build errors related to GTK and richmemo:
+# https://wiki.freepascal.org/RichMemo#2.1.0_.28trunk.2Flater.29
+
+# DEB_LAZARUS = "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.2RC2/lazarus-project_2.2.0RC2-0_amd64.deb/download"
+# DEB_FPC_LAZ = "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.2RC2/fpc-laz_3.2.2-210709_amd64.deb/download"
+# DEB_FPC_SRC = "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%202.2RC2/fpc-src_3.2.2-210709_amd64.deb/download"
+
+
+install-lazarus-linux:
+	DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk2.0-dev
+	wget $(DEB_LAZARUS) -O lazarus-project.deb
+	wget $(DEB_FPC_LAZ) -O fpc-laz.deb
+	wget $(DEB_FPC_SRC) -O fpc-src.deb
+	dpkg -i fpc-laz.deb
+	dpkg -i fpc-src.deb
+	dpkg -i lazarus-project.deb
+
+DMG_FPC = "https://sourceforge.net/projects/lazarus/files/Lazarus%20macOS%20x86-64/Lazarus%202.2.0/fpc-3.2.2.intelarm64-macosx.dmg/download"
+DMG_FPC_PKG = "fpc-3.2.2.intelarm64-macosx/fpc-3.2.2-intelarm64-macosx.mpkg/Contents/Packages/fpc-3.2.2-intelarm64-macosx.pkg"
+DMG_LAZARUS = "https://sourceforge.net/projects/lazarus/files/Lazarus%20macOS%20x86-64/Lazarus%202.2.0/Lazarus-2.2.0-0-x86_64-macosx.pkg/download"
+
+install-lazarus-mac:
+	wget $(DMG_FPC) -q -O fpc.dmg
+	7z x fpc.dmg
+	sudo installer -pkg $(DMG_FPC_PKG) -target /
+	wget $(DMG_LAZARUS) -q -O lazarus.pkg
+	sudo installer -pkg lazarus.pkg -target /
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # SmartSetApps
+
+[![Build](https://github.com/KinesisCorporation/SmartSetApps/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/KinesisCorporation/SmartSetApps/actions/workflows/build.yml)
+
 This repository is for SmartSet apps used for Kinesis Corporation keyboards and foot pedals.
 All apps are build using Lazarus IDE (pascal programming language): https://www.lazarus-ide.org/.
 These apps currently support Windows 32-bit and MacOS 32-bit/64-bit.

--- a/SmartSetSavantElite/u_const_pedal.pas
+++ b/SmartSetSavantElite/u_const_pedal.pas
@@ -14,6 +14,7 @@ interface
 uses
   Classes, SysUtils, lcltype, FileUtil, Controls, LazUTF8 , Graphics, Buttons
   {$ifdef Win32}, Windows, jwawinuser{$endif}
+  {$ifdef Linux}, LCLIntf{$endif}
   {$ifdef Darwin},LCLIntf, CocoaUtils, CocoaAll{$endif};
 
 type

--- a/SmartSetSavantElite/u_form_keypress.pas
+++ b/SmartSetSavantElite/u_form_keypress.pas
@@ -1703,6 +1703,9 @@ const
   {$ifdef Darwin}
   LINE_HEIGHT = 20;
   {$endif}
+  {$ifdef Linux}
+  LINE_HEIGHT = 20; // wild guess
+  {$endif}
 begin
    memoSender := TRichMemo(Sender);
 


### PR DESCRIPTION
This PR configures CI via GitHub Actions.

## Highlights

- Every push and PR will trigger a build of all four apps on three platforms (Mac 64 / Windows 32 / Linux 64)

- Artifacts are saved so you can download the latest binaries ([Example green build](https://github.com/jrr/SmartSetApps/actions/runs/155818767))

- The Makefile can be used for command-line builds (e.g. `make smartset_fsedge`), and it handles dependencies when `lazbuild` doesn't.


## Details

- It took only a few small code changes to get Linux builds going. (`SmartSetSavantElite/u_form_keypress.pas` and both `u_const.pas` files)

- I wound up setting a `--widgetset` for Windows in order to avoid errors related to LCL and cocoa.

- Of the binaries the build produces, the only combination I've tested is Edge/Pro on Mac since that's what I have readily available. For what it's worth, the Mac app appears to work: it's able to see and write settings on both my Edge and my Pro.

----- 

I hope this is useful for the project and for supporting further community contributions.

I'm new to Pascal and Lazarus and would welcome feedback on anything I've done here.